### PR TITLE
meta: add stale bot config (reference unleash/.github)

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,1 @@
+_extends: .github


### PR DESCRIPTION
This change adds a stale bot configuration with a reference to the [org-wide Unleash configuration](https://github.com/Unleash/.github/blob/main/.github/stale.yml).

## About the change

We're adding stale bot as a way to help us manage issues that don't see any activity. When that happens, it's usually because we don't have further resources to work on something or because we're missing information. These issues often go forgotten and end up lying around open. This is an attempt to get around that.

The config file contains the details for how long the bot waits before touching an issue and then how much longer before it closes it if no further activity occurs. (Currently set to 30 and 10 days respectively.)

## Keeping issues open

If there are long-standing issues that should _not_ be closed or marked as stale, you can label it with one of the `exemptLabels` in the stale config file (for instance: `pinned`). That'll keep stale bot from touching the issue at all.

## For maintainers

We know there are differing views on whether stale bots are healthy or not, and we would not want to impose a bot on a repo that we do not control. So if you're not sure this is a good idea (or if you're sure that it _isn't_), let us know, and we'll have a discussion. If we come to the conclusion that it's not the right decision (for whatever reason), then we're happy to leave the bot out.

Further, if you're happy to accept the stale bot, but don't like the org-wide configuration, then we can also override parts or all of the config to make it fit better with this repo.