### PR TITLE
chore: bump svelte project dependencies

### DIFF
--- a/Svelte/package-lock.json
+++ b/Svelte/package-lock.json
@@ -22,7 +22,7 @@
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-svelte": "^2.46.1",
 				"globals": "^16.0.0",
-				"happy-dom": "^17.0.0",
+				"happy-dom": "^20.9.0",
 				"prettier": "^3.3.3",
 				"prettier-plugin-svelte": "^4.0.1",
 				"svelte": "^5.55.7",
@@ -1497,6 +1497,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/whatwg-mimetype": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+			"integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.60.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
@@ -2214,6 +2231,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/es-module-lexer": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -2738,14 +2768,18 @@
 			}
 		},
 		"node_modules/happy-dom": {
-			"version": "17.6.3",
-			"resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-17.6.3.tgz",
-			"integrity": "sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug==",
+			"version": "20.9.0",
+			"resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+			"integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"webidl-conversions": "^7.0.0",
-				"whatwg-mimetype": "^3.0.0"
+				"@types/node": ">=20.0.0",
+				"@types/whatwg-mimetype": "^3.0.2",
+				"@types/ws": "^8.18.1",
+				"entities": "^7.0.1",
+				"whatwg-mimetype": "^3.0.0",
+				"ws": "^8.18.3"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -4204,16 +4238,6 @@
 				}
 			}
 		},
-		"node_modules/webidl-conversions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/whatwg-mimetype": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -4265,6 +4289,28 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/Svelte/package.json
+++ b/Svelte/package.json
@@ -23,7 +23,7 @@
 		"@testing-library/jest-dom": "^6.0.0",
 		"@testing-library/svelte": "^5.3.1",
 		"@types/node": "^22.0.0",
-		"happy-dom": "^17.0.0",
+		"happy-dom": "^20.9.0",
 		"vitest": "^3.0.0",
 		"globals": "^16.0.0",
 		"typescript-eslint": "^8.0.0",


### PR DESCRIPTION
I've noticed it being flagged for security reasons so bumping. 